### PR TITLE
Major Syntax Change and Initial CLI Compatibility

### DIFF
--- a/APIcli.py
+++ b/APIcli.py
@@ -1,0 +1,105 @@
+import json
+import requests
+import ECMapi
+
+# ---- Functions ----
+# -------------------
+def debug(text,db):
+    if db == True:
+        print(text)
+# ------------------
+
+print("For ECM access [1]\nFor router access [2]")
+selection = input("selection:")
+
+if selection == 1:
+    baseurl = "https://www.cradlepointecm.com/api/v2/"
+    headers,users = ECMapi.readECMkeys()
+    print(headers)
+    print(users)
+    api = ECMapi.API(headers)
+    
+elif selection == 2:
+    publicip = raw_input("Public IP: ")
+    user = raw_input("Username: ")
+    password = raw_input("Password: ")
+    baseurl = "http://"+publicip+":8080/api/"
+    headers = {
+        'Content-Type': 'application/json'}
+    requests.get(baseurl, auth=requests.auth.HTTPDigestAuth(user,password))
+
+
+directory = ""
+db = False # Debugging False
+while True:
+    prompt = raw_input("> ")
+
+    if prompt == "ECM":
+        val = users.keys()
+    elif prompt[:4] == "ECM ":
+        val = ECMapi.authECMuser(prompt[4:],users)
+        if type(val) != str:
+            val,api = "current user: "+val[0],ECMapi.API(val[1])
+
+    elif prompt == "debug":
+        val = "debugging!!"
+        db = True # Set debugging True
+        
+    elif prompt[0:3] == 'cd ':
+        directory = prompt[3:]
+        debug(prompt,db) # Debug line
+        val = directory # Debug line
+
+    elif prompt[0:4] == "val ":
+        debug(prompt[4:],db)
+        if type(val) == str:
+            val = json.loads(val)
+        try:
+            try:
+                val = val[int(prompt[4:])]
+            except:
+                val = val[prompt[4:]]
+        except:
+            print("value error")
+        
+    elif prompt[0:4] == "get ":
+        print(baseurl+directory+prompt[4:])
+        val = api.get(directory+prompt[4:])
+        debug(baseurl+directory+prompt[4:],db) # Debug line
+        
+    elif prompt[0:6] == "patch ":
+        print(prompt)
+        val = api.patch(directory, prompt[6:])
+        
+    elif prompt[0:4] == "put ":
+        val = api.put(directory, prompt[4:])
+        debug(baseurl+directory+" "+prompt,db) # Debug line
+
+    elif prompt[0:5] == "post ":
+        prompt = prompt[5:]
+        rp = requests.post(baseurl+prompt.split(" ")[0],data=prompt.split(" ")[1],headers=headers)
+        print(rp,"--->",rp.content)
+        val = rp
+        
+    elif prompt == "exit":
+        break
+
+    elif prompt == "help":
+        val = """available commands:
+cd     --> changes the directory URL
+get    --> performs a get command on the provided URL
+set    --> performs a set command on on the given URL
+put    --> performs a put command at the previously set directory with the argument as the data
+patch  --> performs a patch command on the previously set directory with the argument as the data
+ECM    --> sets the ECM user for API access (users are defined in ECMkeys.txt) Alone it specifies available accounts
+val    --> provides the details of an object or dictionary value from the previously run get command
+exit   --> exits the application
+help   --> displays this information
+debug  --> enables debug output
+                    """
+    else:
+        debug(prompt,db)
+        val = "Type help for more info."
+
+    print(val)
+

--- a/ECMapi.py
+++ b/ECMapi.py
@@ -14,15 +14,18 @@ class API:
         self.headers = headers
         self.routerdetails = {}
 
-    def get(self,call,filters,paginate=1):
+    def get(self,call,paginate=1,**filters):
         # basic GET call to the API
         output = []
-        call = baseurl+call+"?"+filters
+        if filters != {}: filters = buildfilters(**filters)
+        else: filters = ""
+        call = baseurl+call+filters
         while call != None:
             val = requests.get(call, headers=self.headers)
             if str(val) == "<Response [200]>":
                 val = json.loads(val.content)
-                output.extend(val["data"])
+                if "data" in val: output.extend(val["data"])
+                else: output = val
             else:
                 print(val)
                 raise ValueError(str(call)+"  -->  "+str(val)+":  "+str(val.content)) # helps debug bad calls
@@ -31,27 +34,31 @@ class API:
             call = val["meta"]["next"]
         return output
 
-    def patch(self,call,filters,data):
+    def patch(self,call,data,**filters):
         # for future implementations
-        output = requests.patch(baseurl+call+"?"+filters, data=data, headers=self.headers)
-        if str(output) == "<Response [200]>":
+        if filters != {}: filters = buildfilters(**filters)
+        else: filters = ""
+        output = requests.patch(baseurl+call+filters, data=data, headers=self.headers)
+        if str(output) == "<Response [202]>":
             output = json.loads(output.content)
         else:
             print(output)
             raise ValueError(str(call)+"  -->  "+str(output)+":  "+str(output.content)) # helps debug bad calls
         return output
 
-    def put(self,call,filters,data):
+    def put(self,call,data,**filters):
         # for future implementations
-        output = requests.put(baseurl+call+"?"+filters, data=data, headers=self.headers)
-        if str(output) == "<Response [200]>":
+        if filters != {}: filters = buildfilters(**filters)
+        else: filters = ""
+        output = requests.put(baseurl+call+filters, data=data, headers=self.headers)
+        if str(output) == "<Response [202]>":
             output = json.loads(output.content)
         else:
             print(output)
             raise ValueError(str(call)+"  -->  "+str(output)+":  "+str(output.content)) # helps debug bad calls
         return output
 
-    def delete(self,call,filters):
+    def delete(self,call,**filters):
         return output
 
     # ------- High level calls -------
@@ -59,9 +66,8 @@ class API:
     # Most high level call can pass any special filters to the base level call
 
     def devices(self,**kwargs):
-        filters = buildfilters({"fields":"id,name,group.name,mac,state,account.name", "limit": "500"},**kwargs)
         output = {}
-        val = self.get("routers/",filters,paginate=0) # max returned entries per page is 500. polls only the stats we care about
+        val = self.get("routers/",fields="id,name,group.name,mac,state,account.name",limit="500",paginate=0,**kwargs) # max returned entries per page is 500. polls only the stats we care about
         output["devicelist"] = [[t["state"],stripurl(t["id"]),t["name"],t.get("group",{"name":None})["name"],stripurl(t["account"]["name"][0:8]),t["mac"]] for t in val]
         routerids = output["devicelist"]
         return output
@@ -69,7 +75,7 @@ class API:
     def stats(self):
         # home page stats generation 2 calls + the alerts below
         output = {}
-        val = self.get("routers/","fields=config_status,state&limit=500") # this determines what devices in an account are online / offline
+        val = self.get("routers/",fields="config_status,state",limit="500") # this determines what devices in an account are online / offline
         n=[0,0,0,0]
         for t in val:
             if t["state"] == "online":
@@ -80,7 +86,7 @@ class API:
                 n[3]+=1
         n[2] = n[0]+n[1]
         output["RouterState"] = [n]
-        val = self.get("net_devices/","fields=type,homecarrid,summary&mode=wan&limit=500") # and this shows what carriers, etc. are online / available / offline
+        val = self.get("net_devices/",fields="type,homecarrid,summary",mode="wan",limit="500") # and this shows what carriers, etc. are online / available / offline
         n = {}
         for t in [e for e in val if not e["summary"] in ("disconnected", "configure error", "configureerror", "unplugged")]:
             print(t)
@@ -94,49 +100,45 @@ class API:
         output["CarrierState"] = [[a]+b for a,b in n.items()]
         return(output)
 
-    def alerts(self,limit,**kwargs):
-        # pulls a number of alerts for the account
-        output = {}
-        if len(routerids) < 1:
-            routerids.extend([t["id"] for t in self.get("routers/","limit=500",paginate=0)]) # call for router IDs to enumerate through if they haven't been found before, this only occurs since 100 device IDs can be queried at once
-        for t in range(0,len(routerids[1])/100+1,1):
-            routerlist = ",".join([e[1] for e in routerids[t*100:(t+1)*100]])
-            filters = buildfilters({"fields":"detected_at,friendly_info,router","limit":"500","router__in":routerlist},**kwargs)
-            val = self.get("router_alerts/",filters,paginate=0)
-        val.sort(reverse=True) # ordered and displayed by newest first
-        output["%ALERTS%"] =[[t["detected_at"][:t["detected_at"].find(".")].replace("T"," - "),self.get("routers/","fields=name&id="+t["router"][t["router"].find("routers/")+8:-1])[0]["name"],t["friendly_info"]] for t in val[0:limit]]
-        return(output)
-
     def activitylog(self,**kwargs):
         # pulls %limit number of logs. straigt forward, ECM activity log pulled down 
         output = {}
-        filters = buildfilters({"limit":"5"},**kwargs)
-        val = self.get("activity_logs/",filters)
-        print(val)
+        val = self.get("activity_logs/",limit="5",**kwargs)
         output["%ACTIVITYLOG%"] =[[t["created_at"][:t["created_at"].find(".")].replace("T"," - "),t["attributes"]["actor"].get("username",t["attributes"]["actor"].get("name")),"%ACTIVITY"+str(t["activity_type"])+"%"] for t in val] 
         return(output)   
 
+    def alerts(self,limit,**kwargs):
+        # pulls a number of alerts for the account
+        if len(routerids) < 1:
+            routerids.extend([t["id"] for t in self.get("routers/",limit="500",paginate=0)]) # call for router IDs to enumerate through if they haven't been found before, this only occurs since 100 device IDs can be queried at once
+        for t in range(0,len(routerids[1])/100+1,1):
+            routerlist = ",".join([e for e in routerids[t*100:(t+1)*100]])
+            val = self.get("router_alerts/",fields="detected_at,friendly_info,router",limit="500",router__in=routerlist,paginate=0,**kwargs)
+        val.sort(reverse=True) # ordered and displayed by newest first
+        output =[[t["detected_at"][:t["detected_at"].find(".")].replace("T"," - "),self.get("routers/",fields="name&id="+t["router"][t["router"].find("routers/")+8:-1])[0]["name"],t["friendly_info"]] for t in val[0:limit]]
+        return(output)
+
     def router_setdetails(self,MAC):
         # used to set the variable for router details so we don't have to make this call all the time for the other operations
-        output = self.get("routers/","mac="+MAC+"&fields=account.id,account.name,group,id,name")[0] # account info for a device
+        output = self.get("routers/",mac=MAC,fields="account.id,account.name,group,id,name")[0] # account info for a device
         self.routerdetails = output
         return output
     
     def router_signalsamples(self,writefile=False):
         if self.routerdetails == {}: return("Must call router_setdetails first!")
         output = {}
-        val = self.get("net_devices","router.id="+self.routerdetails["id"]+"&mode=wan&fields=id,summary") # find used interfaces for this router
+        val = self.get("net_devices",special={"router.id":self.routerdetails["id"]},mode="wan",fields="id,summary") # find used interfaces for this router
         for t in val:
             if t["summary"] in ("disconnected", "configure error", "configureerror", "unplugged"):
                 pass
-            output[t["id"]] = self.get("net_device_signal_samples/","limit=24&net_device="+t["id"]) # polls signal history, 1 call per interface
+            output[t["id"]] = self.get("net_device_signal_samples/",limit="24",net_device=t["id"]) # polls signal history, 1 call per interface
         if writefile:
             with open("signalhistory.txt", 'wb') as f: f.write(json.dumps(output))
         return output
 
     def router_readconfig(self,writefile=False):
         if self.routerdetails == {}: return("Must call router_setdetails first!")
-        output = self.get("configuration_managers/","router.id="+self.routerdetails["id"]+"&fields=suspended,configuration,pending")[0]
+        output = self.get("configuration_managers/",special={"router.id":self.routerdetails["id"]},fields="suspended,configuration,pending")[0]
         if writefile:
             with open("routerconfig.txt", 'wb') as f: f.write(json.dumps(output))
         return output
@@ -145,7 +147,7 @@ class API:
         if self.routerdetails == {}: return("Must call router_setdetails first!")
         if "paginate" not in kwargs: paginate = 1
         else: paginate = kwargs['paginate']
-        output = self.get("router_logs/","limit=500&router="+self.routerdetails["id"],paginate=paginate)
+        output = self.get("router_logs/",limit="500",router=self.routerdetails["id"],paginate=paginate)
         with open("routerlog.csv", 'wb') as f:
             writer = csv.writer(f)
             writer.writerow(["time","level","source","message"])
@@ -178,9 +180,11 @@ def stripurl(url):
     except:
         return(url)
 
-def buildfilters(defaults,**kwargs):
-    [kwargs.update({t:k}) for t,k in defaults.items() if not kwargs.has_key(t)]
-    return("&".join([t+"="+k for t,k in kwargs.items()]))
+def buildfilters(**kwargs):
+    if kwargs.has_key("special"):
+        kwargs.update(kwargs["special"])
+        del kwargs["special"]
+    return("?"+"&".join([t+"="+k for t,k in kwargs.items()]))
 
 def readECMkeys():
     # reads the file for available ECM API keys and auutomatically selects the specified default
@@ -217,5 +221,7 @@ if __name__ == "__main__":
 ##        v = api.stats()
 ##        v = api.alerts(5)
 ##        v = api.activitylog()
-        v = api.router_createcase("00304416ec94")
+##        v = api.router_createcase("00304416ec94")
+        v = api.get("routers/?fields=id,name")
+        print(v)
     except: raise


### PR DESCRIPTION
Changed format to api.get(call,**filters) where filters can be specified
by variables. ex. api.get("routers/",limit="50",fields="name")

Can still call filters within the call name if need be, ex.
api.get("routers/?fields=name&limit=50")
